### PR TITLE
Flatten the labels specified by docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,24 +17,20 @@ USER cardboardci
 ARG build_date
 ARG version
 ARG vcs_ref
-LABEL maintainer = "CardboardCI" \
-    \
-    org.label-schema.schema-version = "1.0" \
-    \
-    org.label-schema.name = "svgtools" \
-    org.label-schema.version = "${version}" \
-    org.label-schema.build-date = "${build_date}" \
-    org.label-schema.release= = "CardboardCI version:${version} build-date:${build_date}" \
-    org.label-schema.vendor = "cardboardci" \
-    org.label-schema.architecture = "amd64" \
-    \
-    org.label-schema.summary = "Rasterize SVGs" \
-    org.label-schema.description = "Tools for working with Scalable Vector Graphics (SVG) files" \
-    \
-    org.label-schema.url = "https://gitlab.com/cardboardci/images/svgtools" \
-    org.label-schema.changelog-url = "https://gitlab.com/cardboardci/images/svgtools/releases" \
-    org.label-schema.authoritative-source-url = "https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/svgtools" \
-    org.label-schema.distribution-scope = "public" \
-    org.label-schema.vcs-type = "git" \
-    org.label-schema.vcs-url = "https://gitlab.com/cardboardci/images/svgtools" \
-    org.label-schema.vcs-ref = "${vcs_ref}" \
+LABEL maintainer="CardboardCI"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="svgtools"
+LABEL org.label-schema.version="${version}"
+LABEL org.label-schema.build-date="${build_date}"
+LABEL org.label-schema.release="CardboardCI version:${version} build-date:${build_date}"
+LABEL org.label-schema.vendor="cardboardci"
+LABEL org.label-schema.architecture="amd64"
+LABEL org.label-schema.summary="Rasterize SVGs"
+LABEL org.label-schema.description="Tools for working with Scalable Vector Graphics (SVG) files"
+LABEL org.label-schema.url="https://gitlab.com/cardboardci/images/svgtools"
+LABEL org.label-schema.changelog-url="https://gitlab.com/cardboardci/images/svgtools/releases"
+LABEL org.label-schema.authoritative-source-url="https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/svgtools"
+LABEL org.label-schema.distribution-scope="public"
+LABEL org.label-schema.vcs-type="git"
+LABEL org.label-schema.vcs-url="https://gitlab.com/cardboardci/images/svgtools"
+LABEL org.label-schema.vcs-ref="${vcs_ref}"


### PR DESCRIPTION
The previous way of laying out the labels was causing some syntax issues, and made reading the image a bit difficult. For now I think it is best to just have all of the labels as their own line (layer).

This PR coverts the labels from a single layer to multiple layers (e.g. multiple LABEL commands). This resolves syntax errors with the labels, as well as keeping them a bit more consistent in style.